### PR TITLE
Fix concurrent access to calendar cache

### DIFF
--- a/Classes/DateTimeParsers.swift
+++ b/Classes/DateTimeParsers.swift
@@ -24,7 +24,11 @@ final class GPXDateParser {
     
     #if !os(Linux)
     /// Caching Calendar such that it can be used repeatedly without reinitializing it.
-    private static var calendarCache = [Int : Calendar]()
+    private static let utcCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }()
     /// Components of Date stored together
     private var components = DateComponents()
     #endif // !os(Linux)
@@ -72,17 +76,10 @@ final class GPXDateParser {
         components.month = month.pointee
         components.second = second.pointee
         
-        if let calendar = Self.calendarCache[0] {
-            return calendar.date(from: components)
-        }
-        
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        Self.calendarCache[0] = calendar
-        return calendar.date(from: components)
+        return Self.utcCalendar.date(from: components)
         #endif
     }
-    
+
     /// Parses a year string as native Date type.
     func parse(year string: String?) -> Date? {
         guard let NonNilString = string else {
@@ -99,14 +96,7 @@ final class GPXDateParser {
         #else // os(Linux)
         components.year = year.pointee
         
-        if let calendar = Self.calendarCache[1] {
-            return calendar.date(from: components)
-        }
-        
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
-        Self.calendarCache[1] = calendar
-        return calendar.date(from: components)
+        return Self.utcCalendar.date(from: components)
         #endif
     }
 }


### PR DESCRIPTION
When parsing GPX files currently, concurrent access to the same static variable triggered a crash.

Instead, just initialize the Calendar once using `static let`, which is thread-safe (immutable and atomic)

There used to be two initialized elems (calendarCache[0] and calendarCache[1]), but they held the same calendar. We can just have a shared immutable one.

Fixes #101